### PR TITLE
Fix utf-8 charset encoding

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -157,7 +157,7 @@ class Page
                         }
                     }
 
-                    $this->content = $dom->saveHTML($body);
+                    $this->content = utf8_decode($dom->saveHTML($body));
                     $this->tidyStartOfContent();
                     return;
                 }
@@ -231,7 +231,7 @@ class Page
                     }
                 }
 
-                $this->content = $dom->saveHTML($body);
+                $this->content = utf8_decode($dom->saveHTML($body));
                 return;
             }
         }


### PR DESCRIPTION
Hi,
I'm working on a plugin's component using this repo to render a french version of the documentation and faced encoding issue.

[Because no charset is present in `$this->content`, encoding doesn't work properly](https://www.php.net/manual/en/domdocument.savehtml.php#119813), even if you defined it in the DomDocument object constructor (which is useless btw because [it's the default values](https://www.php.net/manual/fr/class.domdocument.php): see the notes part).